### PR TITLE
Fix certain gifs from Giphy/Tenor not downloading

### DIFF
--- a/main.py
+++ b/main.py
@@ -924,6 +924,10 @@ async def main():
     print("\nExtracting URLs...")
     parser = ProtobufParser()
     urls = parser.extract_urls_simple(protobuf_data)
+
+    # Fix some URLs' formatting
+    badurl = re.compile("http.+/https?/")
+    urls = [badurl.sub("https://", u) for u in urls]
     
     if not urls:
         print("Error: No URLs found!")
@@ -973,4 +977,5 @@ if __name__ == "__main__":
         sys.exit(0)
     except Exception as e:
         print(f"\nUnexpected error: {e}")
+
         sys.exit(1)


### PR DESCRIPTION
With this URL patch, I was able to download my favourites with 100% success rate.
One down side is, there may be duplicates of certain gifs, but better than missing 1/3 of my library without it.