### PR TITLE
Fixed Tenor and Discord URL resolving and duplicated attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.idea/
+
+downloads/
+logs/
+
+# prevent commiting updated data file
+data.json

--- a/main.py
+++ b/main.py
@@ -151,6 +151,7 @@ class URLResolver:
 
     def __init__(self, rate_limiter: RateLimiter):
         self.rate_limiter = rate_limiter
+        self.tenor_cache = {}
 
     @staticmethod
     def clean_url(url: str) -> str:
@@ -318,27 +319,40 @@ class URLResolver:
     
     async def resolve_tenor_url(self, client: httpx.AsyncClient, url: str) -> List[str]:
         """Resolve Tenor URL to direct media URL"""
+
+        if url in self.tenor_cache:
+            return self.tenor_cache[url]
+
         try:
             domain = self.extract_domain(url)
             await self.rate_limiter.wait_for_domain(domain)
             
             try:
-                # For Tenor, we'll try to get the MP4 directly
-                # Tenor URLs often have a pattern like /view/name-gif-ID
-                parsed = urlparse(url)
-                path = parsed.path
-                
-                # Extract ID from path
-                if '/view/' in path:
-                    gif_id = path.split('/view/')[1].split('-')[-1]
-                    if gif_id:
-                        # Try different Tenor CDN URLs
-                        possible_urls = [
-                            f"https://media.tenor.com/{gif_id}.mp4",
-                            f"https://media.tenor.com/{gif_id}.gif",
-                            f"https://c.tenor.com/{gif_id}.gif",
-                        ]
-                        return possible_urls
+                resp = await client.get(url, follow_redirects=True)
+
+                if resp.status_code != 200:
+                    return []
+
+                html_text = resp.text
+
+                patterns = [
+                    r'https://media\.tenor\.com/[^\s\"\']+\.gif',
+                    r'https://media\.tenor\.com/[^\s\"\']+\.mp4',
+                    r'https://c\.tenor\.com/[^\s\"\']+\.gif',
+                    r'https://c\.tenor\.com/[^\s\"\']+\.mp4'
+                ]
+
+                found = []
+
+                # Find patterns in HTML code
+                for pattern in patterns:
+                    matches = re.findall(pattern, html_text)
+
+                    for match in matches:
+                        clean = match.split("?")[0]
+
+                        if clean not in found:
+                            found.append(clean)
                 
                 return []
                     

--- a/main.py
+++ b/main.py
@@ -24,8 +24,6 @@ import time
 import random
 import hashlib
 
-from dev import normalize_bytes
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -682,7 +680,7 @@ class GifDownloader:
     def file_hash(self, path: str) -> str:
         h = hashlib.sha256()
         with open(path, 'rb') as f:
-            data = normalize_bytes(f.read())
+            data = self.normalize_bytes(f.read())
             h.update(data)
         return h.hexdigest()
     

--- a/main.py
+++ b/main.py
@@ -47,6 +47,8 @@ MEDIA_TYPES = {
     'video/quicktime': ('.mov', 'mp4'),
 }
 
+DISCORD_TOKEN = ""
+
 # Rate limiting configuration
 RATE_LIMIT_DELAY = 0.1
 MAX_REQUESTS_PER_DOMAIN = 10
@@ -146,38 +148,33 @@ class RateLimiter:
 
 class URLResolver:
     """Resolve special URLs to direct media URLs"""
-    
+
     def __init__(self, rate_limiter: RateLimiter):
         self.rate_limiter = rate_limiter
-    
+
     @staticmethod
     def clean_url(url: str) -> str:
         """Clean and normalize URL"""
         if not url:
             return url
-        
+
         # Decode HTML entities
         url = html.unescape(url)
-        
+
         # Fix URLs that start with slash
         if url.startswith('/') and not url.startswith('//'):
             url = 'https:' + url
-        
-        # Remove tracking parameters
+
+        return url
+
+    @staticmethod
+    def is_discord_attachment(url: str) -> bool:
         parsed = urlparse(url)
-        
-        filtered_params = []
-        for key, values in parse_qs(parsed.query).items():
-            if key in ['ex', 'is', 'hm']:
-                filtered_params.extend([f"{key}={v}" for v in values])
-        
-        new_query = '&'.join(filtered_params) if filtered_params else ''
-        new_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-        if new_query:
-            new_url += f"?{new_query}"
-        
-        return new_url
-    
+        return (
+            parsed.netloc in ('cdn.discordapp.com', 'media.discordapp.net')
+            and '/attachments/' in parsed.path
+        )
+
     @staticmethod
     def extract_domain(url: str) -> str:
         """Extract domain from URL"""
@@ -370,6 +367,8 @@ class URLResolver:
             # Route to appropriate resolver
             if 'images-ext-' in domain:
                 return await self.resolve_discord_proxy_url(client, url)
+            elif self.is_discord_attachment(url):
+                return [url]
             elif 'tenor.com' in domain:
                 return await self.resolve_tenor_url(client, url)
             elif 'imgur.com' in domain:
@@ -380,6 +379,40 @@ class URLResolver:
         except Exception as e:
             logger.debug(f"Error in resolve_url for {url}: {e}")
             return [url] if self.is_valid_url(url) else []
+
+
+    async def bulk_refresh_discord_urls(self, client: httpx.AsyncClient, urls: List[str]) -> Dict[str, str]:
+        """Refresh Discord CDN URLs"""
+        if not DISCORD_TOKEN or not urls:
+            return {}
+
+        headers = {"Authorization": DISCORD_TOKEN, "Content-Type": "application/json"}
+        refreshed: Dict[str, str] = {}
+
+        for i in range(0, len(urls), 50):
+            batch = urls[i:i+50]
+            try:
+                # Fetch new URLs
+                # https://docs.discord.food/resources/message#refresh-attachment-urls
+                resp = await client.post(
+                    "https://discord.com/api/v10/attachments/refresh-urls",
+                    headers=headers,
+                    json={"attachment_urls": batch},
+                    timeout=httpx.Timeout(15.0)
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+                # Retrieve new URLs
+                for item in data.get("refreshed_urls", []):
+                    original = item.get("original")
+                    fresh = item.get("refreshed")
+                    if original and fresh:
+                        refreshed[original] = fresh
+            except Exception as e:
+                logger.debug(f"Bulk refresh failed for batch {i}: {e}")
+
+        return refreshed
 
 
 class ProtobufParser:
@@ -612,6 +645,17 @@ class GifDownloader:
                 resolved_urls.append(url)
         
         print(f"\rResolved {self.stats.resolved} URLs")
+
+        discord_urls = [u for u in resolved_urls if URLResolver.is_discord_attachment(u)]
+        if discord_urls and DISCORD_TOKEN:
+            print(f"\nRefreshing {len(discord_urls)} Discord attachment URLs...")
+            refreshed_map = await resolver.bulk_refresh_discord_urls(client, discord_urls)
+            print(f"Refreshed {len(refreshed_map)} URLs")
+            resolved_urls: List[str] = [
+                refreshed_map.get(u) or u
+                for u in resolved_urls
+            ]
+
         return resolved_urls
     
     async def download_file(self, url: str, index: int) -> bool:
@@ -869,7 +913,13 @@ async def main():
     print("Discord Favorite GIF Downloader")
     print("Author: nloginov")
     print("="*50)
-    
+
+    # Get Discord token for refreshing URLs later
+    global DISCORD_TOKEN
+    token_input = input("Enter your Discord token (leave blank to skip): ").strip()
+    if token_input:
+        DISCORD_TOKEN = token_input
+
     # Find input file
     input_files = ['data.json', 'data.txt', 'input.json', 'input.txt']
     input_file = None

--- a/main.py
+++ b/main.py
@@ -22,6 +22,9 @@ import mimetypes
 import html
 import time
 import random
+import hashlib
+
+from dev import normalize_bytes
 
 # Configure logging
 logging.basicConfig(
@@ -482,6 +485,7 @@ class GifDownloader:
         self.progress = {"done": 0, "total": 0}
         self.url_cache = {}
         self.last_status_length = 0
+        self.downloaded = {}
         
     def clear_line(self):
         """Clear the current line in terminal"""
@@ -671,6 +675,16 @@ class GifDownloader:
             ]
 
         return resolved_urls
+
+    def normalize_bytes(self, data: bytes) -> bytes:
+        return data.replace(b'\r\n', b'\n').strip()
+
+    def file_hash(self, path: str) -> str:
+        h = hashlib.sha256()
+        with open(path, 'rb') as f:
+            data = normalize_bytes(f.read())
+            h.update(data)
+        return h.hexdigest()
     
     async def download_file(self, url: str, index: int) -> bool:
         """Download a single file"""
@@ -695,7 +709,7 @@ class GifDownloader:
                     
                     # Get file path
                     file_path = self.get_file_path(url, content_type, index)
-                    
+
                     # Check if file already exists
                     if file_path.exists():
                         self.stats.skipped += 1
@@ -752,6 +766,21 @@ class GifDownloader:
                     # Save file
                     file_path.parent.mkdir(parents=True, exist_ok=True)
                     file_path.write_bytes(content)
+
+                    try:
+                        h = self.file_hash(str(file_path))
+                    except:
+                        return False
+
+                    if h in self.downloaded:
+                        self.stats.skipped += 1
+                        self.progress["done"] += 1
+                        self.print_progress("exists")
+
+                        os.remove(file_path)
+                        return True
+                    else:
+                        self.downloaded[h] = str(file_path)
                     
                     # Update stats
                     self.stats.successful += 1

--- a/main.py
+++ b/main.py
@@ -484,6 +484,7 @@ class GifDownloader:
         self.url_cache = {}
         self.last_status_length = 0
         self.downloaded = {}
+        self.downloaded_lock = asyncio.Lock()
         
     def clear_line(self):
         """Clear the current line in terminal"""
@@ -547,6 +548,19 @@ class GifDownloader:
         if self.client:
             await self.client.aclose()
             self.client = None
+
+    def normalize_discord_url(self, url: str) -> str:
+        # Matches cdn.discordapp.com and media.discordapp.net attachment URLs.
+        # Groups: (host_type, tld, channel_id, attachment_id, filename)
+        # Strips query params (?ex=...&is=...&hm=...) so cdn vs media variants map to the same key.
+        discord_attachment_re = re.compile(
+            r'https://(cdn|media)\.discordapp\.(com|net)/attachments/(\d+)/(\d+)/([^?#]+)')
+
+        m = discord_attachment_re.match(url)
+        if m:
+            _host_type, _tld, channel_id, attachment_id, filename = m.groups()
+            return f"attachments/{channel_id}/{attachment_id}/{filename}"
+        return url
     
     def sanitize_filename(self, filename: str) -> str:
         """Sanitize filename"""
@@ -672,7 +686,20 @@ class GifDownloader:
                 for u in resolved_urls
             ]
 
-        return resolved_urls
+        # Remove duplicate URLs (same file can appear on media.discordapp.net and cdn.discordapp.com)
+        seen_norm: set = set()
+        deduped: List[str] = []
+        for u in resolved_urls:
+            key = self.normalize_discord_url(u)
+            if key not in seen_norm:
+                seen_norm.add(key)
+                deduped.append(u)
+
+        removed = len(resolved_urls) - len(deduped)
+        if removed:
+            print(f"Removed {removed} duplicate Discord attachment URL(s)")
+
+        return deduped
 
     def normalize_bytes(self, data: bytes) -> bytes:
         return data.replace(b'\r\n', b'\n').strip()
@@ -696,6 +723,17 @@ class GifDownloader:
                     self.progress["done"] += 1
                     self.print_progress("invalid")
                     return False
+
+                # Check normalized URL key before downloading
+                norm_key = self.normalize_discord_url(url)
+                async with self.downloaded_lock:
+                    if norm_key in self.downloaded:
+                        self.stats.skipped += 1
+                        self.progress["done"] += 1
+                        self.print_progress("duplicate")
+                        return True
+                    # Reserve the slot so concurrent tasks don't race on the same URL
+                    self.downloaded[norm_key] = "pending"
                 
                 client = await self.get_client()
                 domain = URLResolver.extract_domain(url)
@@ -779,6 +817,10 @@ class GifDownloader:
                         return True
                     else:
                         self.downloaded[h] = str(file_path)
+
+                    async with self.downloaded_lock:
+                        self.downloaded[h] = str(file_path)
+                        self.downloaded[norm_key] = str(file_path)
                     
                     # Update stats
                     self.stats.successful += 1


### PR DESCRIPTION
Discord CDN URLs are expiring after a while of not being used so now all Discord URLs are being refreshed before being downloaded, changed Tenor's URL resolving to retrieve the media URL from HTML code as the old method wasn't working. Also fixed attachment duplicates being saved.